### PR TITLE
Handling SWAT2012 monthly and yearly output from .RCH

### DIFF
--- a/R/swat2012_handle_output.R
+++ b/R/swat2012_handle_output.R
@@ -57,8 +57,8 @@ read_swat2012_output <- function(output, thread_path) {
 #'
 extract_swat2012_output_i <- function(out_tbl_i, out_def_i) {
   out_tbl_i %>%
-    select(., 2, all_of(out_def_i$variable)) %>%
-    rename(., unit = 1) %>%
+   	select(., 2,"MON", all_of(out_def_i$variable)) %>% #### Keep the MON column to keep compability with M and Yearly output
+    rename(., c(unit = 1, date = 2)) %>%
     add_id(.) %>% # Revised, uses now ID adding from SWAT+ version
     mutate_output_i(., out_def_i) # Revised, uses now mutate from SWAT+ version
 }

--- a/R/swat2012_run_swat.R
+++ b/R/swat2012_run_swat.R
@@ -301,11 +301,20 @@ run_swat2012 <- function(project_path, output, parameter = NULL,
       output_list$parameter <- parameter[c('values', 'definition')]
     }
 
+
+
     output_list$simulation <- tidy_simulations(sim_result)
 
+### To keep compability with montly output
+
+ if(run_info$simulation_period$output_interval == "m"){
+      output_list$simulation  <- map(output_list$simulation, ~ filter(.x, date %in% 1:12))
+    }
+    
     if(add_date) {
       ## Create date vector from the information in model_setup
       date <- get_date_vector_2012(model_setup)
+	  output_list$simulation <- map(output_list$simulation , ~ select(.x,-date))
       output_list$simulation <- map(output_list$simulation, ~ bind_cols(date, .x))
     }
 

--- a/R/swat2012_run_swat.R
+++ b/R/swat2012_run_swat.R
@@ -310,7 +310,10 @@ run_swat2012 <- function(project_path, output, parameter = NULL,
  if(run_info$simulation_period$output_interval == "m"){
       output_list$simulation  <- map(output_list$simulation, ~ filter(.x, date %in% 1:12))
     }
-    
+
+ if(run_info$simulation_period$output_interval %in% c("y","2")){
+      output_list$simulation  <- map(output_list$simulation, ~ filter(.x, date > 1900))
+    }
     if(add_date) {
       ## Create date vector from the information in model_setup
       date <- get_date_vector_2012(model_setup)


### PR DESCRIPTION
In the function run_swat2012, when the output_interval is either "m" or "y" and the return_output = TRUE and  add_date = TRUE the code returner a error message due the size of the matrix.

Backtrace:
▆
1. └─SWATrunR::run_swat2012(...)
2. └─purrr::map(output_list$simulation, ~bind_cols(date, .x))
3. └─purrr:::map_("list", .x, .f, ..., .progress = .progress)
4. ├─purrr:::with_indexed_errors(...)
5. │ └─base::withCallingHandlers(...)
6. ├─purrr:::call_with_cleanup(...)
7. └─SWATrunR (local) .f(.x[[i]], ...)
8. └─dplyr::bind_cols(date, .x)

The changes on the code is a work around to solve this problem.